### PR TITLE
pick only module sources with local paths

### DIFF
--- a/main.go
+++ b/main.go
@@ -4,11 +4,12 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"github.com/hashicorp/terraform-config-inspect/tfconfig"
 	"os"
 	"os/exec"
 	"path"
 	"strings"
+
+	"github.com/hashicorp/terraform-config-inspect/tfconfig"
 )
 
 type cfg struct {
@@ -29,6 +30,10 @@ func getTerraformDependencies(folder string) (map[string]*tfconfig.Module, error
 
 	for _, res := range module.ModuleCalls {
 		expandedModulePath := path.Clean(folder + "/" + res.Source)
+		// pick only modules with source in local paths
+		if !tfconfig.IsModuleDir(res.Source) {
+			continue
+		}
 
 		deps, err := getTerraformDependencies(expandedModulePath)
 		if err != nil {


### PR DESCRIPTION
terraform supports multiple sources for modules. terraform-diff fails with a non local source. This PR ensures that we generate module dependencies only for modules with sources in local path. https://www.terraform.io/language/modules/sources#local-paths