### PR TITLE
fix: check whole module path

### DIFF
--- a/fixtures/main.tf
+++ b/fixtures/main.tf
@@ -1,0 +1,7 @@
+module "test_local" {
+  source = "./module"
+}
+
+module "test_remote" {
+  source = "github.com/something/module"
+}

--- a/fixtures/module/main.tf
+++ b/fixtures/module/main.tf
@@ -1,0 +1,3 @@
+output "test" {
+  value = "foo"
+}

--- a/main.go
+++ b/main.go
@@ -31,7 +31,7 @@ func getTerraformDependencies(folder string) (map[string]*tfconfig.Module, error
 	for _, res := range module.ModuleCalls {
 		expandedModulePath := path.Clean(folder + "/" + res.Source)
 		// pick only modules with source in local paths
-		if !tfconfig.IsModuleDir(res.Source) {
+		if !tfconfig.IsModuleDir(expandedModulePath) {
 			continue
 		}
 

--- a/main_test.go
+++ b/main_test.go
@@ -1,6 +1,9 @@
 package main
 
 import (
+	"fmt"
+	"os"
+	"strings"
 	"testing"
 )
 
@@ -100,5 +103,29 @@ func TestGetFoldersToPlan(t *testing.T) {
 				t.Errorf("failed test %d, got %+v, wanted %+v", testI, toPlan, testCase.want)
 			}
 		}
+	}
+}
+
+func TestGetTerraformDependencies(t *testing.T) {
+	wd, _ := os.Getwd()
+	path := fmt.Sprintf("%s/%s", wd, "./fixtures")
+	got, _ := getTerraformDependencies(path)
+
+	want := "fixtures/module"
+	doNotWant := "github.com/something/module"
+
+	found := false
+
+	for key, _ := range got {
+		if strings.Contains(key, doNotWant) {
+			t.Errorf("Found unwanted remote module name %s", doNotWant)
+		}
+		if strings.Contains(key, want) {
+			found = true
+		}
+	}
+
+	if found == false {
+		t.Errorf("Did not find local module name %s", want)
 	}
 }


### PR DESCRIPTION
The recent change (https://github.com/contentful-labs/terraform-diff/pull/1) to skip non-local paths seems broken:

```
failed getting dependencies for folder ./production/teams_iam: Error processing: Failed to read module directory: Module directory production/something/s3::https:/s3-us-east-2.amazonaws.com/some-public-module-code.zip does not exist or cannot be read.     
```

With this change and some debug println, now removed:

```
terraform/production/something/s3::https:/s3-us-east-2.amazonaws.com/some-public-module-code.zip is not a local path
```