### PR TITLE
Use Github Actions to automatically publish docker images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,44 @@
+name: build-push
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - '*'
+    tags:
+      - 'v*'
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+
+      - name: test
+        run: make docker-test
+
+      - name: build
+        run: make docker-image
+
+      - name: Log in to GHCR
+        run: |
+          echo "${{ github.token }}" | docker login https://ghcr.io -u ${GITHUB_ACTOR} --password-stdin
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: publish-latest
+        run: |
+          docker tag ${{ github.repository }}:latest ghcr.io/${{ github.repository }}:latest
+          docker push ghcr.io/${{ github.repository }}:latest
+        if: github.ref == 'refs/heads/master'
+
+      - name: publish-branch
+        run: |
+          docker tag ${{ github.repository }}:latest ghcr.io/${{ github.repository }}:${GITHUB_REF##*/}
+          docker push ghcr.io/${{ github.repository }}:${GITHUB_REF##*/}
+        if: startsWith(github.ref, 'refs/heads/') && github.ref != 'refs/heads/master'
+
+      - name: publish-tag
+        run: |
+          docker tag ${{ github.repository }}:latest ghcr.io/${{ github.repository }}:${GITHUB_REF##*/}
+          docker push ghcr.io/${{ github.repository }}:${GITHUB_REF##*/}
+        if: startsWith(github.ref, 'refs/tags/v')

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.13-alpine as build
+FROM golang:1.18-alpine as build
 
 RUN apk add --no-cache ca-certificates git
 WORKDIR $GOPATH/src/github.com/contentful-labs/terraform-diff
@@ -6,7 +6,7 @@ WORKDIR $GOPATH/src/github.com/contentful-labs/terraform-diff
 COPY . ./
 RUN CGO_ENABLED=0 GOOS=linux go build -mod=vendor -a -tags netgo -ldflags '-w' .
 
-FROM alpine:3.11
+FROM alpine:3.17
 RUN apk add --no-cache git
 COPY --from=build /go/src/github.com/contentful-labs/terraform-diff/terraform-diff terraform-diff
 ENTRYPOINT ["/terraform-diff"]

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,18 @@
 #!/usr/bin/make -f
 
+.PHONY: test build docker-test docker-build docker-image
+
+test:
+	go test ./...
+
 build:
+	CGO_ENABLED=0 GOOS=linux go build -mod=vendor -a -tags netgo -ldflags '-w' .
+
+docker-test:
+	docker run -t -v $$PWD:/go/src/github.com/yannh/redis-dump-go -w /go/src/github.com/yannh/redis-dump-go golang:1.18 make test
+
+docker-build:
+	docker run -t -v $$PWD:/go/src/github.com/yannh/redis-dump-go -w /go/src/github.com/yannh/redis-dump-go golang:1.18 make build
+
+docker-image:
 	docker build -t contentful-labs/terraform-diff:latest .


### PR DESCRIPTION
This adds a basic CI to automatically publish Docker images to GHCR.