### PR TITLE
Mark all git directories as safe in docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,5 @@ RUN CGO_ENABLED=0 GOOS=linux go build -mod=vendor -a -tags netgo -ldflags '-w' .
 FROM alpine:3.17
 RUN apk add --no-cache git
 COPY --from=build /go/src/github.com/contentful-labs/terraform-diff/terraform-diff terraform-diff
+RUN git config --global --add safe.directory '*'
 ENTRYPOINT ["/terraform-diff"]


### PR DESCRIPTION
It seems git can fail with `fatal: detected dubious ownership in repository at <path>` in some cases of mounting the git files into the container. This change should prevent that from happening. 