### PR TITLE
ci: build multi-arch Docker image for amd64 and arm64

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,19 +11,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: test
         run: make docker-test
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -31,7 +31,7 @@ jobs:
 
       - name: Docker metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |
@@ -40,7 +40,7 @@ jobs:
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/master' }}
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,34 +11,39 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: test
         run: make docker-test
 
-      - name: build
-        run: docker build -t ${{ github.repository }}:latest .
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: Log in to GHCR
-        run: |
-          echo "${{ github.token }}" | docker login https://ghcr.io -u ${GITHUB_ACTOR} --password-stdin
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: publish-latest
-        run: |
-          docker tag ${{ github.repository }}:latest ghcr.io/${{ github.repository }}:latest
-          docker push ghcr.io/${{ github.repository }}:latest
-        if: github.ref == 'refs/heads/master'
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=ref,event=branch,enable=${{ github.ref != 'refs/heads/master' }}
+            type=ref,event=tag
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/master' }}
 
-      - name: publish-branch
-        run: |
-          docker tag ${{ github.repository }}:latest ghcr.io/${{ github.repository }}:${GITHUB_REF##*/}
-          docker push ghcr.io/${{ github.repository }}:${GITHUB_REF##*/}
-        if: startsWith(github.ref, 'refs/heads/') && github.ref != 'refs/heads/master'
-
-      - name: publish-tag
-        run: |
-          docker tag ${{ github.repository }}:latest ghcr.io/${{ github.repository }}:${GITHUB_REF##*/}
-          docker push ghcr.io/${{ github.repository }}:${GITHUB_REF##*/}
-        if: startsWith(github.ref, 'refs/tags/v')
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Makefile
+++ b/Makefile
@@ -15,4 +15,4 @@ docker-build:
 	docker run -t -v $$PWD:/go/src/github.com/contentful-labs/terraform-diff -w /go/src/github.com/contentful-labs/terraform-diff golang:1.24 make build
 
 docker-image:
-	docker build -t contentful-labs/terraform-diff:latest .
+	docker buildx build --platform linux/amd64,linux/arm64 -t contentful-labs/terraform-diff:latest .


### PR DESCRIPTION
## Summary

- Add QEMU and Docker Buildx setup to CI to support cross-platform builds
- Build and push `linux/amd64` and `linux/arm64` images in a single step via `docker/build-push-action`
- Replace manual `docker login` / `docker tag` / `docker push` shell commands with official Docker GitHub Actions
- Consolidate three separate publish steps into one using `docker/metadata-action` for tag management
- Update `Makefile` `docker-image` target to use `docker buildx build --platform linux/amd64,linux/arm64`
- Bump `actions/checkout` from v3 to v4

🤖 Generated with [Claude Code](https://claude.com/claude-code)