### PR TITLE
fix: [ACT-2690] add explicit GITHUB_TOKEN permissions to build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,10 @@ on:
       - '*'
     tags:
       - 'v*'
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Adds explicit `permissions` block to `build.yml` workflow
- Sets `contents: read` (for checkout) and `packages: write` (for GHCR push)
- Resolves CodeQL finding: workflow defaulted to repo-level permissions, violating least-privilege principle

Fixes [ACT-2690](https://contentful.atlassian.net/browse/ACT-2690)

## Test plan

- [ ] Workflow runs successfully on push (build + GHCR push still work)
- [ ] No other jobs/steps require additional permission scopes

🤖 Generated with [Claude Code](https://claude.com/claude-code)